### PR TITLE
Dark Mode Toggle

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,18 @@ theme:
     repo: fontawesome/brands/github
   logo: art/icon16.svg
   palette:
-    primary: black
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: black
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to light mode
   features:
     - navigation.instant
     - navigation.tabs


### PR DESCRIPTION
Adds a switch to the top of the page which toggles on or of the Slate color scheme for Material.
This makes reading more accessible to users with sensitive eyes.

The primary color of the banner stays black either way, to match the Consulo theme.

I referenced this page in the making of this PR:
https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors

![Screenshot](https://user-images.githubusercontent.com/30361266/148115911-38ed74cc-579a-4f5a-b51d-06956771ea74.png)
